### PR TITLE
Add asynchronous methods

### DIFF
--- a/lib/AnyEvent/HTTP/LWP/UserAgent.pm
+++ b/lib/AnyEvent/HTTP/LWP/UserAgent.pm
@@ -385,7 +385,7 @@ sub request_async
 	$referral->uri($referral_uri);
 
 	if($self->redirect_ok($referral, $response)) {
-	    $self->request_async($referral, $arg, $size, $response)->cb(sub{ $cv->send(shfit->recv) }); return;
+	    $self->request_async($referral, $arg, $size, $response)->cb(sub{ $cv->send(shift->recv) }); return;
 	} else {
 	    $cv->send($response); return;
 	}

--- a/lib/AnyEvent/HTTP/LWP/UserAgent.pm
+++ b/lib/AnyEvent/HTTP/LWP/UserAgent.pm
@@ -113,7 +113,7 @@ sub conn_cache {
 The following methods are async version of corresponding methods w/o _async suffix.
 Parameters are identical as originals.
 However, return value becomes condition variable.
-You can use it in a synchornous way by blocking wait
+You can use it in a synchronous way by blocking wait
 
   $ua->simple_request_async(@args)->recv
 

--- a/t/async.t
+++ b/t/async.t
@@ -1,0 +1,95 @@
+use strict;
+use Test::More;
+use AnyEvent::HTTP::LWP::UserAgent;
+use AnyEvent;
+
+BEGIN {
+    eval q{ require Test::TCP } or plan skip_all => 'Could not require Test::TCP';
+    eval q{ require HTTP::Server::Simple::CGI } or plan skip_all => 'Could not require HTTP::Server::Simple::CGI';
+}
+
+{
+    package HTTP::Server::Simple::Test;
+    our @ISA = 'HTTP::Server::Simple::CGI';
+
+    sub print_banner { }
+
+    sub handle_request {
+        my ($self, $cgi) = @_;
+
+        if($cgi->url(-path_info=>1) =~ m,/redirected$,) {
+
+            print "HTTP/1.0 200 OK\r\n";
+            print "Content-Type: text/html\r\n";
+            print "Set-Cookie: test=abc; path=/\r\n";
+            print "\r\n";
+            print <<__HTML__;
+<html>
+  <head>
+    <title>Test Web Page</title>
+    <base href="http://www.example.com/">
+  </head>
+  <body>
+    <p>blahblahblha</p>
+  </body>
+</html>
+__HTML__
+        } else {
+            print "HTTP/1.0 301 Moved Permanently\r\n";
+            print "Location: ",$cgi->url(-path_info=>1),"redirected\r\n";
+            print "\r\n";
+            print <<__HTML__;
+<html>
+  <head>
+    <title>Test Web Page</title>
+  </head>
+  <body>
+    <a href="/redirected">Redirected to</p>
+  </body>
+</html>
+__HTML__
+        }
+    }
+}
+
+plan tests => 14;
+
+my $cv = AE::cv;
+my %tests = (
+	DELETE => 'AnyEvent::HTTP::LWP::UserAgent::delete_async',
+	GET    => 'AnyEvent::HTTP::LWP::UserAgent::get_async',
+	HEAD   => 'AnyEvent::HTTP::LWP::UserAgent::head_async',
+	POST   => 'AnyEvent::HTTP::LWP::UserAgent::post_async',
+	PUT    => 'AnyEvent::HTTP::LWP::UserAgent::put_async',
+);
+
+Test::TCP::test_tcp(
+    server => sub {
+        my $port = shift;
+        my $server = HTTP::Server::Simple::Test->new($port);
+        $server->run;
+    },
+    client => sub {
+        my $port = shift;
+
+        $cv->begin;
+        for my $test (keys %tests) {
+# We do not share $ua because of cookie_jar separation
+            my $ua = AnyEvent::HTTP::LWP::UserAgent->new(cookie_jar => {});
+            $ua->requests_redirectable([$test]);
+
+            $cv->begin;
+            my $method = $tests{$test};
+            $ua->$method("http://localhost:$port/")->cb(sub {
+                my $res = shift->recv;
+                ok $res->is_success;
+                like $ua->cookie_jar->as_string, qr/test=abc/, $test . ': $ua->cookie_jar set';
+                is $res->base, 'http://www.example.com/', $test . ': $res->base set' if $test ne 'HEAD';
+                $cv->end;
+            });
+        }
+        $cv->end;
+
+        $cv->recv;
+    },
+);


### PR DESCRIPTION
Using AnyEvent::HTTP inside made LWP::UserAgent event-based friendly. However, $cv->recv without callback made blocking wait. Therefore, In AnyEvent without Coro, this will make recursive blocking wait error in most cases. One solution is to return condition variable and delegate choice how to wait results to users. On the other hand, this module intended to be interface-compatible with LWP::UserAgent. So, I added some _async methods whose parameters identical to originals, which means methods without _async suffix, but return value becomes condition variable. It will make this module more friendly to plain AnyEvent without Coro, 
