### PR TITLE
fix crash in weird corner case

### DIFF
--- a/lib/AnyEvent/HTTP/LWP/UserAgent.pm
+++ b/lib/AnyEvent/HTTP/LWP/UserAgent.pm
@@ -197,6 +197,8 @@ sub simple_request_async {
         # to read RFCs more carefully.
         my $headers = HTTP::Headers->new;
         while (my ($header, $value) = each %$h) {
+            # some pages like http://www.games.com/recipes/recepty-domashnego-ketchupa have empty headers and cause crash
+            next unless ($header);
             # In previous versions it was a place where heavily used
             # Coro stack (if Coro used) when you had pseudo-header URL
             # and URL was really big.


### PR DESCRIPTION
Some pages have empty headers with empty values and this is causing HTTP::Headers to fail.
