### PR TITLE
fix handling of Location headers with commas

### DIFF
--- a/lib/AnyEvent/HTTP/LWP/UserAgent.pm
+++ b/lib/AnyEvent/HTTP/LWP/UserAgent.pm
@@ -202,11 +202,13 @@ sub simple_request_async {
             # and URL was really big.
             # Now it's not such a big problem, we delete URL pseudo-header
             # and haven't sudden gigantous headers (I hope).
-            my @v = $value =~ /^([^ ].*?[^ ],)*([^ ].*?[^ ])$/;
-            @v = grep { defined($_) } @v;
-            if (scalar(@v) > 1) {
-                @v = map { s/,$//; $_ } @v;
-                $value = \@v;
+            unless ($header eq 'location') { # in case of Location header this is useless and dangerous
+                my @v = $value =~ /^([^ ].*?[^ ],)*([^ ].*?[^ ])$/;
+                @v = grep { defined($_) } @v;
+                if (scalar(@v) > 1) {
+                    @v = map { s/,$//; $_ } @v;
+                    $value = \@v;
+                }
             }
             $headers->header($header => $value);
         }


### PR DESCRIPTION
Also, your header splitting by comma is broken anyway.
Line `my @v = $s =~ /^([^ ].*?[^ ],)*([^ ].*?[^ ])$/;` copied from your module.

``` perl
$ perl -MData::Dumper -e 'my $s = q[aa,bb,cc,dd,ee]; my @v = $s =~ /^([^ ].*?[^ ],)*([^ ].*?[^ ])$/; print Dumper(\@v);'
$VAR1 = [
          'dd,',
          'ee'
        ];
```
